### PR TITLE
CANDI-913: Update for Ubuntu 18.04 compatibility (take 1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: jobseeker/docker-library:ruby-2.4-ci
+      - image: jobseeker/docker-library:ruby-2.4-ci-bionic
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS
@@ -11,12 +11,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache
+            - v2-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - v2-gem-cache-{{ arch }}-{{ .Branch }}
+            - v2-gem-cache
       - run: bundle install --path vendor/bundle
       - save_cache:
-          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: v2-gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
       - run: mkdir /reports

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
   specs:
     byebug (10.0.2)
     chronic (0.10.2)
-    cld (0.7.0)
+    cld (0.8.0)
       ffi
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -21,7 +21,7 @@ GEM
       sixarm_ruby_unaccent (~> 1.1)
       unicode_utils (~> 1.4)
     diff-lcs (1.3)
-    ffi (1.9.25)
+    ffi (1.11.2)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     i18n_data (0.8.0)
@@ -64,4 +64,4 @@ DEPENDENCIES
   timecop
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
## What does it do?

- [x] Update the CI images to build on Ubuntu 18.04.
- [x] Update the `cld` dependency.

## Also see

- https://jobseeker.atlassian.net/browse/CANDI-913